### PR TITLE
fix: reimplement hasher using rosetta-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "array-init"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23589ecb866b460d3a0f1278834750268c607e8e28a1b982c907219f3178cd72"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,23 +187,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
-name = "hash_test"
+name = "hasher"
 version = "0.1.0"
 dependencies = [
+ "candid",
+ "crc32fast",
  "fmt",
  "hex",
  "ic-ledger-types",
+ "num-traits",
  "serde",
+ "serde-hex",
  "serde_bytes",
  "serde_cbor",
  "sha2",
+ "strum_macros",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "ic-cdk"
@@ -276,6 +299,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "num-bigint"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.83"
+version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "ec96c6a92621310b51366f1e28d05ef11489516e93be030060e5fc12024a49d6"
 dependencies = [
  "unicode-ident",
 ]
@@ -356,11 +391,22 @@ checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-hex"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca37e3e4d1b39afd7ff11ee4e947efae85adfddf4841787bfa47c470e96dc26d"
+dependencies = [
+ "array-init",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -384,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -417,6 +463,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
+]
+
+[[package]]
 name = "stacker"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +482,19 @@ dependencies = [
  "libc",
  "psm",
  "winapi",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.66",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,21 @@
 [package]
-name = "hash_test"
+name = "hasher"
 version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+candid = "0.10.8"
+crc32fast = "1.4.2"
 fmt = "0.1.0"
-hex = "0.4.3"
+hex = { version = "0.4.3", features = ["serde"] }
 ic-ledger-types = "0.11.0"
-serde = "1.0.202"
+num-traits = "0.2.19"
+serde = { version = "1.0", features = ["derive"] }
+serde-hex = "0.1.0"
 serde_bytes = "0.11.14"
 serde_cbor = "0.11.2"
 sha2 = "0.10.8"
+strum_macros = "0.26.2"
+
+[lib]
+path = "src/lib/mod.rs"

--- a/src/lib/hashof.rs
+++ b/src/lib/hashof.rs
@@ -1,0 +1,135 @@
+use candid::types::internal::{Type, TypeInner};
+use candid::CandidType;
+use serde::{
+    de::{Deserializer, Visitor},
+    Deserialize, Serialize, Serializer,
+};
+use std::convert::TryInto;
+use std::{fmt, marker::PhantomData, str::FromStr};
+
+/// The length of a block/transaction hash in bytes.
+pub const HASH_LENGTH: usize = 32;
+
+#[derive(Clone, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct HashOf<T> {
+    inner: [u8; HASH_LENGTH],
+    _marker: PhantomData<T>,
+}
+
+impl<T> CandidType for HashOf<T> {
+    fn _ty() -> Type {
+        TypeInner::Vec(TypeInner::Nat8.into()).into()
+    }
+
+    fn idl_serialize<S>(&self, serializer: S) -> Result<(), S::Error>
+    where
+        S: candid::types::Serializer,
+    {
+        serializer.serialize_blob(self.as_slice())
+    }
+}
+
+impl<T: std::clone::Clone> Copy for HashOf<T> {}
+
+impl<T> HashOf<T> {
+    pub fn into_bytes(self) -> [u8; HASH_LENGTH] {
+        self.inner
+    }
+
+    pub fn new(bs: [u8; HASH_LENGTH]) -> Self {
+        HashOf {
+            inner: bs,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.inner
+    }
+}
+
+impl<T> fmt::Display for HashOf<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let res = hex::encode(self.as_slice());
+        write!(f, "{}", res)
+    }
+}
+
+impl<T> FromStr for HashOf<T> {
+    type Err = String;
+    fn from_str(s: &str) -> Result<HashOf<T>, String> {
+        let v = hex::decode(s).map_err(|e| e.to_string())?;
+        let slice = v.as_slice();
+        match slice.try_into() {
+            Ok(ba) => Ok(HashOf::new(ba)),
+            Err(_) => Err(format!(
+                "Expected a Vec of length {} but it was {}",
+                HASH_LENGTH,
+                v.len(),
+            )),
+        }
+    }
+}
+
+impl<T> Serialize for HashOf<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if serializer.is_human_readable() {
+            serializer.serialize_str(&self.to_string())
+        } else {
+            serializer.serialize_bytes(self.as_slice())
+        }
+    }
+}
+
+impl<'de, T> Deserialize<'de> for HashOf<T> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct HashOfVisitor<T> {
+            phantom: PhantomData<T>,
+        }
+
+        impl<'de, T> Visitor<'de> for HashOfVisitor<T> {
+            type Value = HashOf<T>;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(
+                    formatter,
+                    "a hash of type {}: a blob with at most {} bytes",
+                    std::any::type_name::<T>(),
+                    HASH_LENGTH
+                )
+            }
+
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                Ok(HashOf::new(
+                    v.try_into().expect("hash does not have correct length"),
+                ))
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: serde::de::Error,
+            {
+                HashOf::from_str(s).map_err(E::custom)
+            }
+        }
+
+        if deserializer.is_human_readable() {
+            deserializer.deserialize_str(HashOfVisitor {
+                phantom: PhantomData,
+            })
+        } else {
+            deserializer.deserialize_bytes(HashOfVisitor {
+                phantom: PhantomData,
+            })
+        }
+    }
+}

--- a/src/lib/ledger.rs
+++ b/src/lib/ledger.rs
@@ -1,0 +1,251 @@
+use crate::hashof::HashOf;
+use sha2::{Sha256, Digest};
+use serde::{de, de::Error, Deserialize, Serialize};
+use ic_ledger_types::{ Tokens, Memo };
+use candid::CandidType;
+use strum_macros::IntoStaticStr;
+use serde_bytes::ByteBuf;
+use std::{
+    convert::TryInto,
+    fmt::{Display, Formatter},
+};
+
+const HASH_LENGTH: usize = 32;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct ChecksumError {
+    input: [u8; 32],
+    expected_checksum: [u8; 4],
+    found_checksum: [u8; 4],
+}
+
+impl Display for ChecksumError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Checksum failed for {}, expected check bytes {} but found {}",
+            hex::encode(&self.input[..]),
+            hex::encode(self.expected_checksum),
+            hex::encode(self.found_checksum),
+        )
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum AccountIdParseError {
+    InvalidChecksum(ChecksumError),
+    InvalidLength(Vec<u8>),
+}
+
+impl AccountIdentifier {
+    pub fn from_hex(hex_str: &str) -> Result<AccountIdentifier, String> {
+        let hex: Vec<u8> = hex::decode(hex_str).map_err(|e| e.to_string())?;
+        Self::from_slice(&hex[..]).map_err(|err| match err {
+            // Since the input was provided in hex, return an error that is hex-friendly.
+            AccountIdParseError::InvalidLength(_) => format!(
+                "{} has a length of {} but we expected a length of 64 or 56",
+                hex_str,
+                hex_str.len()
+            ),
+            AccountIdParseError::InvalidChecksum(err) => err.to_string(),
+        })
+    }
+
+    /// Converts a blob into an `AccountIdentifier`.
+    ///
+    /// The blob can be either:
+    ///
+    /// 1. The 32-byte canonical format (4 byte checksum + 28 byte hash).
+    /// 2. The 28-byte hash.
+    ///
+    /// If the 32-byte canonical format is provided, the checksum is verified.
+    pub fn from_slice(v: &[u8]) -> Result<AccountIdentifier, AccountIdParseError> {
+        // Try parsing it as a 32-byte blob.
+        match v.try_into() {
+            Ok(h) => {
+                // It's a 32-byte blob. Validate the checksum.
+                check_sum(h).map_err(AccountIdParseError::InvalidChecksum)
+            }
+            Err(_) => {
+                // Try parsing it as a 28-byte hash.
+                match v.try_into() {
+                    Ok(hash) => Ok(AccountIdentifier { hash }),
+                    Err(_) => Err(AccountIdParseError::InvalidLength(v.to_vec())),
+                }
+            }
+        }
+    }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.to_vec())
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        [&self.generate_checksum()[..], &self.hash[..]].concat()
+    }
+
+    pub fn generate_checksum(&self) -> [u8; 4] {
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&self.hash);
+        hasher.finalize().to_be_bytes()
+    }
+}
+
+fn check_sum(hex: [u8; 32]) -> Result<AccountIdentifier, ChecksumError> {
+    // Get the checksum provided
+    let found_checksum = &hex[0..4];
+
+    // Copy the hash into a new array
+    let mut hash = [0; 28];
+    hash.copy_from_slice(&hex[4..32]);
+
+    let account_id = AccountIdentifier { hash };
+    let expected_checksum = account_id.generate_checksum();
+
+    // Check the generated checksum matches
+    if expected_checksum == found_checksum {
+        Ok(account_id)
+    } else {
+        Err(ChecksumError {
+            input: hex,
+            expected_checksum,
+            found_checksum: found_checksum.try_into().unwrap(),
+        })
+    }
+}
+
+#[derive(
+    Debug, Clone, Copy, CandidType, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash,
+)]
+pub struct TimeStamp {
+    pub timestamp_nanos: u64,
+}
+
+impl<'de> Deserialize<'de> for AccountIdentifier {
+    // This is the canonical way to read a this from string
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+        D::Error: de::Error,
+    {
+        let hex: [u8; 32] = hex::serde::deserialize(deserializer)?;
+        check_sum(hex).map_err(D::Error::custom)
+    }
+}
+
+#[derive(CandidType, Clone, Copy, Hash, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct AccountIdentifier {
+    pub hash: [u8; 28],
+}
+
+impl Serialize for AccountIdentifier {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_hex().serialize(serializer)
+    }
+}
+
+
+/// An operation which modifies account balances
+#[derive(
+    Serialize,
+    Deserialize,
+    CandidType,
+    Clone,
+    Hash,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    IntoStaticStr,
+)]
+pub enum Operation {
+    Burn {
+        from: AccountIdentifier,
+        amount: Tokens,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        spender: Option<AccountIdentifier>,
+    },
+    Mint {
+        to: AccountIdentifier,
+        amount: Tokens,
+    },
+    Transfer {
+        from: AccountIdentifier,
+        to: AccountIdentifier,
+        amount: Tokens,
+        fee: Tokens,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        spender: Option<AccountIdentifier>,
+    },
+    Approve {
+        from: AccountIdentifier,
+        spender: AccountIdentifier,
+        allowance: Tokens,
+        expected_allowance: Option<Tokens>,
+        expires_at: Option<TimeStamp>,
+        fee: Tokens,
+    },
+}
+
+#[derive(
+    Serialize, Deserialize, CandidType, Clone, Hash, Debug, PartialEq, Eq, PartialOrd, Ord,
+)]
+pub struct Transaction {
+    pub operation: Operation,
+    pub memo: Memo,
+    /// The time this transaction was created.
+    pub created_at_time: Option<TimeStamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icrc1_memo: Option<ByteBuf>,
+}
+
+impl Transaction {
+    pub fn new(
+        from: AccountIdentifier,
+        to: AccountIdentifier,
+        spender: Option<AccountIdentifier>,
+        amount: Tokens,
+        fee: Tokens,
+        memo: Memo,
+        created_at_time: TimeStamp,
+    ) -> Self {
+        let operation = Operation::Transfer {
+            from,
+            to,
+            spender,
+            amount,
+            fee,
+        };
+        Transaction {
+            operation,
+            memo,
+            icrc1_memo: None,
+            created_at_time: Some(created_at_time),
+        }
+    }
+}
+
+pub trait LedgerTransaction: Sized {
+    type AccountId: Clone;
+    // type Tokens: Tokens;
+
+    /// Returns the hash of this transaction.
+    fn hash(&self) -> HashOf<Self>;
+}
+
+impl LedgerTransaction for Transaction {
+    type AccountId = AccountIdentifier;
+    // type Tokens = Tokens;
+
+    fn hash(&self) -> HashOf<Self> {
+        let mut state = Sha256::new();
+        state.update(&serde_cbor::ser::to_vec_packed(&self).unwrap());
+        let result = state.finalize();
+        let fixed_result: [u8; HASH_LENGTH] = result.into();
+        HashOf::new(fixed_result)
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -1,0 +1,2 @@
+pub mod ledger;
+pub mod hashof;


### PR DESCRIPTION
many struct definition on ic_ledger_types are actually different with ic rosetta-api, which subsequently introduced hashing incompatibility. 
we borrowed all the incompatible structs and traits, and the re-implemented module now produces identical hash 